### PR TITLE
Update meta_crypto.h

### DIFF
--- a/metalibs/meta_crypto/include/meta_crypto.h
+++ b/metalibs/meta_crypto/include/meta_crypto.h
@@ -6,7 +6,7 @@
 // Containers
 #include <array>
 #include <vector>
-
+#include <string>
 // OpenSSL
 #include <openssl/ecdsa.h>
 #include <openssl/evp.h>


### PR DESCRIPTION
I get this error (string in namespace std does not name a type) while installing core & i added this so it now works ok.